### PR TITLE
fix: updating model to handle null values and throw error

### DIFF
--- a/backend/controllers/controller.go
+++ b/backend/controllers/controller.go
@@ -3,6 +3,7 @@ package controllers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	helpers "github.com/punndcoder28/url-shortner/helpers"
@@ -45,7 +46,14 @@ func CreateURL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hash := helpers.InsertURL(createURLRequest.URL)
+	hash, err := helpers.InsertURL(createURLRequest.URL)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		response := map[string]interface{}{"error": err.Error()}
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
 	url := helpers.CreateTempURLFromHash(hash)
 	response := map[string]interface{}{"url": url}
 	json.NewEncoder(w).Encode(response)

--- a/backend/helpers/db.go
+++ b/backend/helpers/db.go
@@ -28,7 +28,6 @@ func ConnectDB() *gorm.DB {
 }
 
 func CreateURLTable(db *gorm.DB) {
-	db.Migrator().DropTable(&models.URL{})
 	db.AutoMigrate(&models.URL{})
 }
 

--- a/backend/helpers/url.go
+++ b/backend/helpers/url.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash/fnv"
 
@@ -31,13 +32,15 @@ func CreateTempURLFromHash(hash string) string {
 /*
 InsertURL - This function inserts a URL into the database
 */
-func InsertURL(url string) string {
+func InsertURL(url string) (string, error) {
 	db := ConnectDB()
 
 	hashedURL := HashURL(url)
-	fmt.Println("Hashed URL: ", hashedURL)
-	urlRecord := models.URL{Hash: hashedURL, URL: url}
-	db.Create(&urlRecord)
+	urlRecord := models.URL{Hash: hashedURL}
+	result := db.Create(&urlRecord)
+	if result.Error != nil {
+		return "", errors.New(result.Error.Error())
+	}
 
-	return hashedURL
+	return hashedURL, nil
 }

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -4,8 +4,8 @@ import "time"
 
 type URL struct {
 	ID        uint      `gorm:"primaryKey:autoIncrement"`
-	Hash      string    `gorm:"type:string;unique:not null"`
-	URL       string    `gorm:"type:string;not null"`
+	Hash      string    `gorm:"type:string;unique:not null;default:null"`
+	URL       string    `gorm:"type:string;not null;default:null"`
 	CreatedAt time.Time `gorm:"autoCreateTime"`
 }
 


### PR DESCRIPTION
* Updating `URL` model columns to throw error when trying to insert null values to table

Test Plan -
```
curl --location 'http://localhost:8080/api/shorten' \
--header 'Content-Type: application/json' \
--data '{
    "url": "https://www.only.com"
}'
{"error":"ERROR: null value in column \"url\" violates not-null constraint (SQLSTATE 23502)"}
```
