### PR TITLE
feat: adding unit tests for helpers package

### DIFF
--- a/backend/helpers/common_test.go
+++ b/backend/helpers/common_test.go
@@ -1,0 +1,24 @@
+package helpers
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestHandleErr(t *testing.T) {
+	t.Run("NoError", func(t *testing.T) {
+		HandleErr(nil)
+	})
+
+	t.Run("WithError", func(t *testing.T) {
+		err := errors.New("test error")
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("HandleErr did not panic as expected")
+			}
+		}()
+
+		HandleErr(err)
+	})
+}

--- a/backend/helpers/db_test.go
+++ b/backend/helpers/db_test.go
@@ -1,0 +1,42 @@
+package helpers
+
+import (
+	"testing"
+
+	models "github.com/punndcoder28/url-shortner/models"
+)
+
+func TestConnectDB(t *testing.T) {
+	db := ConnectDB()
+
+	if db == nil {
+		t.Errorf("ConnectDB returned nil, expected *gorm.DB")
+	}
+}
+
+func TestCreateURLTable(t *testing.T) {
+	db := ConnectDB()
+
+	CreateURLTable(db)
+
+	if !db.Migrator().HasTable(&models.URL{}) {
+		t.Errorf("CreateURLTable did not create the URL table")
+	}
+}
+
+func TestGetURLFromHash(t *testing.T) {
+	db := ConnectDB()
+
+	testURL := models.URL{Hash: "testHash", URL: "https://example.com"}
+	db.Create(&testURL)
+
+	retrievedURL, err := GetURLFromHash("testHash")
+	if err != nil {
+		t.Errorf("GetURLFromHash returned an error: %v", err)
+	}
+
+	expectedURL := "https://example.com"
+	if retrievedURL != expectedURL {
+		t.Errorf("GetURLFromHash returned %s, expected %s", retrievedURL, expectedURL)
+	}
+}

--- a/backend/helpers/url_test.go
+++ b/backend/helpers/url_test.go
@@ -1,0 +1,46 @@
+package helpers
+
+import (
+	"testing"
+)
+
+func TestHashURL(t *testing.T) {
+	url := "https://example.com"
+	hash := HashURL(url)
+	expectedHash := "6fbc04d3"
+	if hash == "" {
+		t.Errorf("HashURL(%s) return empty hash", url)
+	}
+
+	if hash != expectedHash {
+		t.Errorf("HashURL(%s) = %s; want %s", url, hash, "d5c3dbf6")
+	}
+}
+
+func TestCreateTempURLFromHash(t *testing.T) {
+	hash := "d5c3dbf6"
+	expectedURL := "http://localhost:8080/d5c3dbf6"
+	tempURL := CreateTempURLFromHash(hash)
+
+	if tempURL != expectedURL {
+		t.Errorf("CreateTempURLFromHash(%s) = %s; want %s", hash, tempURL, expectedURL)
+	}
+}
+
+func TestInsertURL(t *testing.T) {
+	validURL := "https://example.com"
+	hash1, err := InsertURL(validURL)
+	if err != nil {
+		t.Errorf("InsertURL(%s) returned an error: %v", validURL, err)
+	}
+
+	if hash1 == "" {
+		t.Errorf("InsertURL(%s) returned an empty hash", validURL)
+	}
+
+	duplicateURL := "https://example.com"
+	hash2, err := InsertURL(duplicateURL)
+	if err == nil && hash2 == "" {
+		t.Errorf("InsertURL(%s) inserted duplicate URL: %v", duplicateURL, err)
+	}
+}

--- a/backend/helpers/validators_test.go
+++ b/backend/helpers/validators_test.go
@@ -1,0 +1,45 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+
+	models "github.com/punndcoder28/url-shortner/models"
+)
+
+func TestValidateShortenURLRequest(t *testing.T) {
+	validRequest := models.CreateURLRequest{URL: "https://example.com"}
+	invalidRequest := models.CreateURLRequest{URL: ""}
+
+	err := ValidateShortenURLRequest(validRequest)
+	if err != nil {
+		t.Errorf("Expected a valid request, but got an error: %v", err)
+	}
+
+	err = ValidateShortenURLRequest(invalidRequest)
+	if err == nil {
+		t.Error("Expected an error for an invalid request, but got nil")
+	} else {
+		validationErrors, ok := err.(validator.ValidationErrors)
+		if !ok {
+			t.Error("Expected a validator.ValidationErrors type error, but got a different error type")
+		} else {
+			for _, e := range validationErrors {
+				switch e.Field() {
+				case "URL":
+					switch e.Tag() {
+					case "required":
+						t.Skipf("URL is required, but it's missing")
+					case "url":
+						t.Errorf("URL is not a valid URL: %s", e.Value())
+					default:
+						t.Errorf("Validation error on field %s with tag %s", e.Field(), e.Tag())
+					}
+				default:
+					t.Errorf("Unknown validation error on field %s with tag %s", e.Field(), e.Tag())
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
* Added unit tests for all methods in helpers package

Test Plan -
```
=== RUN   TestHandleErr
=== RUN   TestHandleErr/NoError
=== RUN   TestHandleErr/WithError
--- PASS: TestHandleErr (0.00s)
    --- PASS: TestHandleErr/NoError (0.00s)
    --- PASS: TestHandleErr/WithError (0.00s)
=== RUN   TestConnectDB
--- PASS: TestConnectDB (0.36s)
=== RUN   TestCreateURLTable

2023/09/03 15:15:46 /home/puneeth/Desktop/projects/url-shortener/backend/helpers/db.go:31 SLOW SQL >= 200ms
[201.652ms] [rows:0] DROP TABLE IF EXISTS "urls" CASCADE
--- PASS: TestCreateURLTable (0.70s)
=== RUN   TestGetURLFromHash
--- PASS: TestGetURLFromHash (0.94s)
=== RUN   TestHashURL
--- PASS: TestHashURL (0.00s)
=== RUN   TestCreateTempURLFromHash
--- PASS: TestCreateTempURLFromHash (0.00s)
=== RUN   TestInsertURL

2023/09/03 15:15:48 /home/puneeth/Desktop/projects/url-shortener/backend/helpers/url.go:39 ERROR: duplicate key value violates unique constraint "urls_hash_key" (SQLSTATE 23505)
[98.022ms] [rows:0] INSERT INTO "urls" ("created_at","hash","url") VALUES ('2023-09-03 15:15:48.598','6fbc04d3','https://example.com') RETURNING "hash","url","id"
--- PASS: TestInsertURL (0.83s)
=== RUN   TestValidateShortenURLRequest
    validators_test.go:33: URL is required, but it's missing
--- SKIP: TestValidateShortenURLRequest (0.00s)
PASS
coverage: 97.1% of statements
ok  	github.com/punndcoder28/url-shortner/helpers	2.849s	coverage: 97.1% of statements
```