### PR TITLE
feat: adding test for duplicate url request body

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -64,4 +64,31 @@ func TestCreateEmptyURL(t *testing.T) {
 	)
 }
 
+func TestCreateDuplicateURL(t *testing.T) {
+	requestBody := strings.NewReader(`{"url":"https://www.google.com"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/shorten", requestBody)
+	w := httptest.NewRecorder()
+
+	CreateURL(w, req)
+
+	resp := w.Result()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode, "Status code should be 500")
+
+	responseBody, err := io.ReadAll(resp.Body)
+
+	assert.NoError(t, err, "Error should be nil while reading response body")
+
+	responseBody = []byte(strings.TrimSuffix(string(responseBody), "\n"))
+
+	expectedResponseBody := `{"error":"ERROR: duplicate key value violates unique constraint \"urls_hash_key\" (SQLSTATE 23505)"}`
+
+	assert.Equal(
+		t,
+		expectedResponseBody,
+		string(responseBody),
+		"Response body should be equal to expected response body",
+	)
+}
+
 func TestGetURL(t *testing.T) {}


### PR DESCRIPTION
* Added unit tests to test out sending duplicate url in request body

Test Plan - 
```
╭─puneeth at puneeth-development in ~/Desktop/projects/url-shortener on feat_empty_url_test✘✘✘
╰─± go test ./... -v -cover
?   	github.com/punndcoder28/url-shortner	[no test files]
?   	github.com/punndcoder28/url-shortner/models	[no test files]
?   	github.com/punndcoder28/url-shortner/routers	[no test files]
?   	github.com/punndcoder28/url-shortner/setup	[no test files]
=== RUN   TestCreateURL
--- PASS: TestCreateURL (0.32s)
=== RUN   TestCreateEmptyURL
--- PASS: TestCreateEmptyURL (0.00s)
=== RUN   TestCreateDuplicateURL

2023/09/18 23:14:27 /home/puneeth/Desktop/projects/url-shortener/helpers/url.go:39 ERROR: duplicate key value violates unique constraint "urls_hash_key" (SQLSTATE 23505)
[85.043ms] [rows:0] INSERT INTO "urls" ("created_at","hash","url") VALUES ('2023-09-18 23:14:27.135','8739bc55','https://www.google.com') RETURNING "hash","url","id"
--- PASS: TestCreateDuplicateURL (0.28s)
=== RUN   TestGetURL
--- PASS: TestGetURL (0.00s)
PASS
coverage: 67.9% of statements
ok  	github.com/punndcoder28/url-shortner/controllers	0.612s	coverage: 67.9% of statements
=== RUN   TestHandleErr
=== RUN   TestHandleErr/WithError
--- PASS: TestHandleErr (0.00s)
    --- PASS: TestHandleErr/WithError (0.00s)
=== RUN   TestHandleNoErr
=== RUN   TestHandleNoErr/NoError
--- PASS: TestHandleNoErr (0.00s)
    --- PASS: TestHandleNoErr/NoError (0.00s)
=== RUN   TestConnectDB
--- PASS: TestConnectDB (1.01s)
=== RUN   TestCreateURLTable

2023/09/17 22:34:57 /home/puneeth/Desktop/projects/url-shortener/helpers/db.go:33 SLOW SQL >= 200ms
[226.071ms] [rows:0] DROP TABLE IF EXISTS "urls" CASCADE
--- PASS: TestCreateURLTable (0.58s)
=== RUN   TestGetURLFromHash
--- PASS: TestGetURLFromHash (0.57s)
=== RUN   TestHashURL
--- PASS: TestHashURL (0.00s)
=== RUN   TestCreateTempURLFromHash
--- PASS: TestCreateTempURLFromHash (0.00s)
=== RUN   TestInsertURL
--- PASS: TestInsertURL (0.29s)
=== RUN   TestInsertDuplicateURL

2023/09/17 22:34:58 /home/puneeth/Desktop/projects/url-shortener/helpers/url.go:39 ERROR: duplicate key value violates unique constraint "urls_hash_key" (SQLSTATE 23505)
[86.232ms] [rows:0] INSERT INTO "urls" ("created_at","hash","url") VALUES ('2023-09-17 22:34:58.216','6fbc04d3','https://example.com') RETURNING "hash","url","id"
--- PASS: TestInsertDuplicateURL (0.28s)
=== RUN   TestValidateShortenURLRequest
--- PASS: TestValidateShortenURLRequest (0.00s)
=== RUN   TestInvalidEmptyShortenURLRequest
--- PASS: TestInvalidEmptyShortenURLRequest (0.00s)
PASS
coverage: 97.1% of statements
ok  	github.com/punndcoder28/url-shortner/helpers	(cached)	coverage: 97.1% of statements

```