### PR TITLE
feat: add unit test for get url controller

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -91,4 +91,22 @@ func TestCreateDuplicateURL(t *testing.T) {
 	)
 }
 
-func TestGetURL(t *testing.T) {}
+func TestGetURL(t *testing.T) {
+	req := httptest.NewRequest("get", "/8739bc55", nil)
+	w := httptest.NewRecorder()
+
+	GetURL(w, req)
+
+	response := w.Result()
+
+	assert.Equal(
+		t,
+		http.StatusSeeOther,
+		response.StatusCode,
+		"Status code should match with redirect status code",
+	)
+
+	_, err := io.ReadAll(response.Body)
+
+	assert.NoError(t, err, "Error should be nil while reading response body")
+}


### PR DESCRIPTION
* Adding unit test for get url controller

Test Plan - 
```
╭─puneeth at puneeth-development in ~/Desktop/projects/url-shortener on main✘✘✘
╰─± go test ./... -v -cover
?   	github.com/punndcoder28/url-shortner	[no test files]
?   	github.com/punndcoder28/url-shortner/models	[no test files]
?   	github.com/punndcoder28/url-shortner/routers	[no test files]
?   	github.com/punndcoder28/url-shortner/setup	[no test files]
=== RUN   TestCreateURL
--- PASS: TestCreateURL (0.38s)
=== RUN   TestCreateEmptyURL
--- PASS: TestCreateEmptyURL (0.00s)
=== RUN   TestCreateDuplicateURL

2023/10/15 12:21:17 /home/puneeth/Desktop/projects/url-shortener/helpers/url.go:39 ERROR: duplicate key value violates unique constraint "urls_hash_key" (SQLSTATE 23505)
[98.133ms] [rows:0] INSERT INTO "urls" ("created_at","hash","url") VALUES ('2023-10-15 12:21:17.211','8739bc55','https://www.google.com') RETURNING "hash","url","id"
--- PASS: TestCreateDuplicateURL (0.32s)
=== RUN   TestGetURL
--- PASS: TestGetURL (0.26s)
PASS
coverage: 85.7% of statements
ok  	github.com/punndcoder28/url-shortner/controllers	0.973s	coverage: 85.7% of statements
=== RUN   TestHandleErr
=== RUN   TestHandleErr/WithError
--- PASS: TestHandleErr (0.00s)
    --- PASS: TestHandleErr/WithError (0.00s)
=== RUN   TestHandleNoErr
=== RUN   TestHandleNoErr/NoError
--- PASS: TestHandleNoErr (0.00s)
    --- PASS: TestHandleNoErr/NoError (0.00s)
=== RUN   TestConnectDB
--- PASS: TestConnectDB (0.80s)
=== RUN   TestCreateURLTable

2023/10/15 12:19:46 /home/puneeth/Desktop/projects/url-shortener/helpers/db.go:33 SLOW SQL >= 200ms
[221.387ms] [rows:0] DROP TABLE IF EXISTS "urls" CASCADE
--- PASS: TestCreateURLTable (0.56s)
=== RUN   TestGetURLFromHash
--- PASS: TestGetURLFromHash (0.60s)
=== RUN   TestHashURL
--- PASS: TestHashURL (0.00s)
=== RUN   TestCreateTempURLFromHash
--- PASS: TestCreateTempURLFromHash (0.00s)
=== RUN   TestInsertURL
--- PASS: TestInsertURL (0.31s)
=== RUN   TestInsertDuplicateURL

2023/10/15 12:19:47 /home/puneeth/Desktop/projects/url-shortener/helpers/url.go:39 ERROR: duplicate key value violates unique constraint "urls_hash_key" (SQLSTATE 23505)
[95.060ms] [rows:0] INSERT INTO "urls" ("created_at","hash","url") VALUES ('2023-10-15 12:19:47.485','6fbc04d3','https://example.com') RETURNING "hash","url","id"
--- PASS: TestInsertDuplicateURL (0.31s)
=== RUN   TestValidateShortenURLRequest
--- PASS: TestValidateShortenURLRequest (0.00s)
=== RUN   TestInvalidEmptyShortenURLRequest
--- PASS: TestInvalidEmptyShortenURLRequest (0.00s)
PASS
coverage: 97.1% of statements
ok  	github.com/punndcoder28/url-shortner/helpers	(cached)	coverage: 97.1% of statements
```