### PR TITLE
feat: handle duplicate url hashing

### DIFF
--- a/helpers/common.go
+++ b/helpers/common.go
@@ -3,6 +3,15 @@ Package helpers provides helper functions for the application.
 */
 package helpers
 
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"gorm.io/gorm"
+
+	"github.com/punndcoder28/url-shortner/models"
+)
+
 /*
 HandleErr - This function panics if there is an error
 */
@@ -10,4 +19,33 @@ func HandleErr(err error) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+/*
+PgError - This function returns a pg error
+*/
+func PgError(err error) *pgconn.PgError {
+	var pgErr *pgconn.PgError
+
+	if errors.As(err, &pgErr) {
+		return pgErr
+	}
+
+	return nil
+}
+
+/*
+FindURLHashFromHash - This function finds the URL from the hash
+*/
+func FindURLHashFromHash(db *gorm.DB, hashString string) (string, error) {
+	var url models.URL
+
+	result := db.Where("hash = ?", hashString).First(&url)
+
+	if result.Error != nil {
+		return "", result.Error
+	}
+
+	urlString := url.Hash
+	return urlString, nil
 }

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -38,6 +38,17 @@ func InsertURL(url string) (string, error) {
 	urlRecord := models.URL{Hash: hashedURL, URL: url}
 	result := db.Create(&urlRecord)
 	if result.Error != nil {
+		if pgErr := PgError(result.Error); pgErr != nil {
+			if pgErr.Code == "23505" {
+				url, err := FindURLHashFromHash(db, hashedURL)
+				if err != nil {
+					return "", errors.New(result.Error.Error())
+				}
+
+				return url, nil
+			}
+		}
+
 		return "", errors.New(result.Error.Error())
 	}
 


### PR DESCRIPTION
* Updated hash url handle to return hash when duplicate url is submitted

Test Plan - The curl request can be made twice to get back the same result
```
curl --location 'http://localhost:8080/api/shorten' \
--header 'Content-Type: application/json' \
--data '{
    "url": "https://www.google.com"
}'

```